### PR TITLE
Fix Bluetrax bug (asset_history sometimes is None) and fix tests

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -71,8 +71,8 @@ async def action_pull_observations(integration:Integration, action_config: PullE
                 await send_observations_to_gundi(observations=[transform(item)for item in batch],
                                                   integration_id=integration.id)
 
-        if asset_history.data:                
-            asset_state[asset.unit_id] = max(item.fixtime for item in asset_history.data)       
+            if asset_history.data:
+                asset_state[asset.unit_id] = max(item.fixtime for item in asset_history.data)
 
     for unit_id, item in asset_state.items():
         await state_manager.set_state(integration_id=integration.id, action_id="pull_observations", state={"latest_fixtime": item.isoformat()}, source_id=unit_id)

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -20,8 +20,9 @@ async def test_set_integration_state(mocker, mock_redis, integration_v2):
         state=state
     )
 
-    mock_redis.Redis.return_value.set.assert_called_once_with(
+    mock_redis.Redis.return_value.setex.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.no-source",
+        7 * 86400,
         '{"last_execution": "' + execution_timestamp + '"}'
     )
 
@@ -62,8 +63,9 @@ async def test_delete_integration_state(mocker, mock_redis, integration_v2):
         state=state
     )
 
-    mock_redis.Redis.return_value.set.assert_called_once_with(
+    mock_redis.Redis.return_value.setex.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.no-source",
+        7 * 86400,
         '{"last_execution": "' + execution_timestamp + '"}'
     )
 
@@ -94,8 +96,9 @@ async def test_set_source_state(mocker, mock_redis, integration_v2, mock_integra
         state=mock_integration_state
     )
 
-    mock_redis.Redis.return_value.set.assert_called_once_with(
+    mock_redis.Redis.return_value.setex.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}",
+        7 * 86400,
         json.dumps(mock_integration_state, default=str)
     )
 
@@ -134,8 +137,9 @@ async def test_delete_state_source_state(mocker, mock_redis, integration_v2, moc
         state=mock_integration_state
     )
 
-    mock_redis.Redis.return_value.set.assert_called_once_with(
+    mock_redis.Redis.return_value.setex.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}",
+        7 * 86400,
         json.dumps(mock_integration_state, default=str)
     )
 


### PR DESCRIPTION
This pull request includes changes to the `app/services/tests/test_state_manager.py` file to update the Redis commands used in the tests. The changes replace the `set` command with the `setex` command to include an expiration time for the keys.

Updates to Redis commands:

* [`app/services/tests/test_state_manager.py`](diffhunk://#diff-72fbc37459f71893f201849a0cd857c086582cb8bc27550d8a44423602370089L23-R25): Updated `test_set_integration_state` to use `setex` with a 7-day expiration time instead of `set`.
* [`app/services/tests/test_state_manager.py`](diffhunk://#diff-72fbc37459f71893f201849a0cd857c086582cb8bc27550d8a44423602370089L65-R68): Updated `test_delete_integration_state` to use `setex` with a 7-day expiration time instead of `set`.
* [`app/services/tests/test_state_manager.py`](diffhunk://#diff-72fbc37459f71893f201849a0cd857c086582cb8bc27550d8a44423602370089L97-R101): Updated `test_set_source_state` to use `setex` with a 7-day expiration time instead of `set`.
* [`app/services/tests/test_state_manager.py`](diffhunk://#diff-72fbc37459f71893f201849a0cd857c086582cb8bc27550d8a44423602370089L137-R142): Updated `test_delete_state_source_state` to use `setex` with a 7-day expiration time instead of `set`.