### PR TITLE
Release 20250122 verb fix

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -71,8 +71,8 @@ async def action_pull_observations(integration:Integration, action_config: PullE
                 await send_observations_to_gundi(observations=[transform(item)for item in batch],
                                                   integration_id=integration.id)
 
-            if asset_history.data:
-                asset_state[asset.unit_id] = max(item.fixtime for item in asset_history.data)
+            if getattr(asset_history, 'data', None):                
+                asset_state[asset.unit_id] = max(item.fixtime for item in asset_history.data)       
 
     for unit_id, item in asset_state.items():
         await state_manager.set_state(integration_id=integration.id, action_id="pull_observations", state={"latest_fixtime": item.isoformat()}, source_id=unit_id)

--- a/app/bluetrax.py
+++ b/app/bluetrax.py
@@ -122,7 +122,11 @@ async def get_asset_history(unit_id: str, start_time: datetime, end_time: dateti
         )
 
         if r.is_success:
-            return HistoryResult(**r.json())
-        else:
-            # TODO: Collect these errors and write to Activity Log.
-            return None
+            try:
+                data = r.json()
+                history = HistoryResult.validate(data)
+                return history
+            except pydantic.ValidationError as ve:
+                raise ve
+
+        r.raise_for_status()

--- a/app/bluetrax.py
+++ b/app/bluetrax.py
@@ -117,10 +117,12 @@ async def get_asset_history(unit_id: str, start_time: datetime, end_time: dateti
           }
     
     async with httpx.AsyncClient() as client:
-        r = await client.get("https://rest.bluetrax.co.ke/AnalyticsService", 
+        r = await client.post("https://rest.bluetrax.co.ke/AnalyticsService", 
                              params={'request': json.dumps(q)}
         )
-        if r.status_code == 200:
+
+        if r.is_success:
             return HistoryResult(**r.json())
         else:
+            # TODO: Collect these errors and write to Activity Log.
             return None

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,43 @@
+import pytest
+
+@pytest.fixture
+def a_good_history_result():
+    return {
+                "response": "success", 
+                "data": [
+                    {
+                        "device_timezone": -8, 
+                        "unit_id": "unit1", 
+                        "fixtime": "01/30/2008 06:55:00 AM",
+                        "alerts": ["alert1"],
+                        "location": "",
+                        "speed": 1, 
+                        "course": 1,
+                        "longitude": 35.5,
+                        "latitude": 1.4,
+                        "reg_no": "REGNO1",
+                        "driver": "Driver Dan"
+                    }
+                ]
+            }
+
+@pytest.fixture
+def a_bad_history_result():
+    return {
+                "response": "success", 
+                "data": [
+                    {
+                        "device_timezone": -8, 
+                        "unit_id": "unit1", 
+                        "fixtime": "13/30/2008 06:55:00 AM",
+                        "alerts": ["alert1"],
+                        "location": "",
+                        "speed": 1, 
+                        "course": 1,
+                        "longitude": 35.5,
+                        "latitude": 1.4,
+                        "reg_no": "REGNO1",
+                        "driver": "Driver Dan"
+                    }
+                ]
+            }

--- a/app/tests/test_bluetrax.py
+++ b/app/tests/test_bluetrax.py
@@ -1,0 +1,64 @@
+import pytest
+import httpx
+from datetime import datetime
+from unittest.mock import AsyncMock
+from pydantic import ValidationError
+from app.bluetrax import get_asset_history, HistoryResult
+
+
+@pytest.mark.asyncio
+async def test_get_asset_history_success(mocker, a_good_history_result):
+    """Test get_asset_history with a successful API response."""
+
+    # Define test input
+    unit_id = "12345"
+    start_time = datetime(2024, 1, 1, 12, 0, 0)
+    end_time = datetime(2024, 1, 1, 14, 0, 0)
+    
+    # Mock API response
+    mock_response_data = a_good_history_result
+    mock_history_result = HistoryResult(**mock_response_data)
+
+    async def mock_post(*args, **kwargs):
+        return httpx.Response(200, json=mock_response_data)
+
+    mocker.patch("httpx.AsyncClient.post", new=mock_post)
+
+    result = await get_asset_history(unit_id, start_time, end_time)
+
+    assert isinstance(result, HistoryResult)
+    assert result == mock_history_result
+
+
+@pytest.mark.asyncio
+async def test_get_asset_history_validation_error(mocker, a_bad_history_result):
+    """Test get_asset_history when API response fails pydantic validation."""
+
+    unit_id = "12345"
+    start_time = datetime(2024, 1, 1, 12, 0, 0)
+    end_time = datetime(2024, 1, 1, 14, 0, 0)
+    
+    async def mock_post(*args, **kwargs):
+        return httpx.Response(200, json=a_bad_history_result)
+
+    mocker.patch("httpx.AsyncClient.post", new=mock_post)
+
+    with pytest.raises(ValidationError):
+        await get_asset_history(unit_id, start_time, end_time)
+
+
+@pytest.mark.asyncio
+async def test_get_asset_history_http_error(mocker):
+    """Test get_asset_history when API returns an HTTP error."""
+
+    unit_id = "12345"
+    start_time = datetime(2024, 1, 1, 12, 0, 0)
+    end_time = datetime(2024, 1, 1, 14, 0, 0)
+
+    async def mock_post(*args, **kwargs):
+        return httpx.Response(500, json={"error": "Internal Server Error"}, request=AsyncMock())
+
+    mocker.patch("httpx.AsyncClient.post", new=mock_post)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await get_asset_history(unit_id, start_time, end_time)

--- a/app/tests/test_handler.py
+++ b/app/tests/test_handler.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timezone
+import httpx
+import pytest
+from unittest.mock import AsyncMock
+from app.actions.handlers import (
+    get_observations,
+)
+
+@pytest.mark.asyncio
+async def test_get_observations(mocker, a_good_history_result):
+
+    mocker.patch('app.bluetrax.httpx.AsyncClient.post', return_value=httpx.Response(200, json=a_good_history_result))
+
+    result = await get_observations("user1", "unit1", datetime(2025, 2, 1, tzinfo=timezone.utc), None)
+
+    assert result.response == "success"
+
+
+@pytest.mark.asyncio
+async def test_get_observations_negative(mocker):
+    # Mimic a 405 for the actual case where the API has been changed from GET to POST.
+    mocker.patch('app.bluetrax.httpx.AsyncClient.post', return_value=httpx.Response(405, json={"response": "error"}, request=AsyncMock()))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        result = await get_observations("user1", "unit1", datetime(2025, 2, 1, tzinfo=timezone.utc), None)
+
+

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 
 services:
 


### PR DESCRIPTION
This is to adapt to a change in Bluetrax's API for downloading location history. The  verb changed from GET to POST.

This  change will also let an HTTP Status error bubble up and be saved as an Activity Log.